### PR TITLE
챕터 14쪽 todo-list에서 remove시에 toggle 문제점 해결

### DIFF
--- a/14/todo-list/src/modules/todos.js
+++ b/14/todo-list/src/modules/todos.js
@@ -51,7 +51,12 @@ export default handleActions({
     */
   },
   [REMOVE]: (state, action) => {
-    const { payload: index } = action;
+    const { payload: id } = action;
+
+    const index = state.findIndex(
+        (todo) => todo.id === id
+    );
+
     return state.delete(index);
   }
 }, initialState);

--- a/14/todo-list/src/modules/todos.js
+++ b/14/todo-list/src/modules/todos.js
@@ -37,7 +37,11 @@ export default handleActions({
     }));
   },
   [TOGGLE]: (state, action) => {
-    const { payload: index } = action;
+    const { payload: id } = action;
+
+    const index = state.findIndex(
+        (todo) => todo.get('id') === id
+    );
     // = const index = action.payload;
     /* 비구조화 할당을 통하여 index라는 레퍼런스에 action.payload란 값을 넣습니다.
     이 작업이 필수는 아니지만, 나중에 이 코드를 보게 되었을 때 여기서의 payload가
@@ -54,7 +58,7 @@ export default handleActions({
     const { payload: id } = action;
 
     const index = state.findIndex(
-        (todo) => todo.id === id
+        (todo) => todo.get('id') === id
     );
 
     return state.delete(index);


### PR DESCRIPTION
- 삭제시 index랑 id랑 맞지 않은 점 
- toggle 부분에서도 삭제 이후 index랑 id가 맞지 않는 점

id를 넘겨주는데 해당 id를 index로 사용하는 논리 문제가 있어서 id를 받아 index를 구하도록 했습니다.
Map의 findIndex 메소드로 id와 index 매치 시켜주는 코드를 넣었습니다.
